### PR TITLE
Reintroduced the clean target for building release

### DIFF
--- a/release/build.xml
+++ b/release/build.xml
@@ -96,9 +96,13 @@
 	
 	<target name="clean">
 	    <delete dir="${release.dir}"/>
-	    <delete dir="${base.dir}/checkout"/>
-	    <delete dir="${base.dir}/docs-bundle"/>
-	    <delete dir="${base.dir}/docs-bundle"/>
+	    <delete dir="${bundle.docs.dir}"/>
+	    <delete includeemptydirs="true" failonerror="true">
+            <fileset dir="${checkout.dir}" defaultexcludes="false">
+	        	<exclude name="*.zip" />
+	        	<exclude name="*.jar" />
+            </fileset>
+		</delete>
 		<delete>
 			<fileset dir="${base.dir}">
 				<include name="restcomm-gmlc-*.*" />
@@ -106,8 +110,7 @@
 		</delete>
 	</target>
 	
-	
-	<target name="release" depends="get-deps,extract-deps,clean-up-restcomm-slee,build-gmlc,copy-gmlc,build-docs,copy-docs,make-final-zip,bundle-documentation" />
+	<target name="release" depends="clean,get-deps,extract-deps,clean-up-restcomm-slee,build-gmlc,copy-gmlc,build-docs,copy-docs,make-final-zip,bundle-documentation" />
 
 	<target name="release-with-jss7-and-ras" depends="build-with-jss7-and-ras.ss7, build-with-jss7-and-ras.ras, release"/>
 	


### PR DESCRIPTION
Fixes an issue exposed by #46 whereby old dependencies could unknowingly be bundled into a release build if the checkout directory was dirtied by an old build.
